### PR TITLE
use bittrix API v1.1 instead of Cryptsy API

### DIFF
--- a/Source/index.html
+++ b/Source/index.html
@@ -56,8 +56,8 @@
           <ul class="navbar-nav">
             <li>
               <p ng-show="btcPrice"><span class="label" ng-class="{'label-success': btcPriceUp, 'label-danger': !btcPriceUp}" title="bitstamp btc/usd price">BTC: ${{btcPrice | humanize:2:'.':','}} <span class="glyphicon" ng-class="{'glyphicon-arrow-up': btcPriceUp, 'glyphicon-arrow-down': !btcPriceUp}" aria-hidden="true"></span></span></p>
-              <p ng-show="rddPrice"><span class="label" ng-class="{'label-success': rddPriceUp, 'label-danger': !rddPriceUp}" title="cryptsy rdd/btc price">RDD: ฿{{rddPrice | humanize:8:'.':','}} <span class="glyphicon" ng-class="{'glyphicon-arrow-up': rddPriceUp, 'glyphicon-arrow-down': !rddPriceUp}" aria-hidden="true"></span></span></p>
-              <p ng-show="rddDollarPrice"><span class="label" ng-class="{'label-success': rddDollarPriceUp, 'label-danger': !rddDollarPriceUp}" title="bitstamp btc * cryptsy rdd price">RDD: ${{rddDollarPrice | humanize:8:'.':','}} <span class="glyphicon" ng-class="{'glyphicon-arrow-up': rddDollarPriceUp, 'glyphicon-arrow-down': !rddDollarPriceUp}" aria-hidden="true"></span></span></p>
+              <p ng-show="rddPrice"><span class="label" ng-class="{'label-success': rddPriceUp, 'label-danger': !rddPriceUp}" title="bittrex rdd/btc price">RDD: ฿{{rddPrice | humanize:8:'.':','}} <span class="glyphicon" ng-class="{'glyphicon-arrow-up': rddPriceUp, 'glyphicon-arrow-down': !rddPriceUp}" aria-hidden="true"></span></span></p>
+              <p ng-show="rddDollarPrice"><span class="label" ng-class="{'label-success': rddDollarPriceUp, 'label-danger': !rddDollarPriceUp}" title="bitstamp btc * bittrex rdd price">RDD: ${{rddDollarPrice | humanize:8:'.':','}} <span class="glyphicon" ng-class="{'glyphicon-arrow-up': rddDollarPriceUp, 'glyphicon-arrow-down': !rddDollarPriceUp}" aria-hidden="true"></span></span></p>
             </li>
           </ul>
         </div>

--- a/Source/js/main.js
+++ b/Source/js/main.js
@@ -59,7 +59,7 @@ reddcoinRocks.directive('compile', ['$compile', function ($compile) {
 reddcoinRocks.service('rddPriceService', ['$http', function($http) {
 	this.getPrice = function() {
 		return $http({
-			url: 'http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20json%20where%20url%3D%22' + encodeURIComponent('http://pubapi.cryptsy.com/api.php?method=singlemarketdata&marketid=169') + '%22&format=json'
+			url: 'http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20json%20where%20url%3D%22' + encodeURIComponent('https://bittrex.com/api/v1.1/public/getticker?market=BTC-RDD') + '%22&format=json'
 		});
 	};
 }]);
@@ -503,8 +503,8 @@ reddcoinRocks.controller('stakingInfo', ['$scope', '$http', 'btcPriceService', '
 	});
 
 	rddPriceService.getPrice().then(function(result) {
-		if (result.data.query.results && result.data.query.results.json.success == 1 && result.data.query.results.json['return']['markets']['RDD']['lasttradeprice']) {
-			$scope.rddPrice = result.data.query.results.json['return']['markets']['RDD']['lasttradeprice'];
+		if (result.data.query.results && result.data.query.results.json.success == "true" && result.data.query.results.json['result']['Last']) {
+			$scope.rddPrice = result.data.query.results.json['result']['Last'];
 			$scope.updateRddDollarPrice($scope.btcPrice, $scope.rddPrice);
 		}
 	});


### PR DESCRIPTION
This uses the bittrex api instead of cryptsy. Note that I didn't see how to refresh the main.min.js so that still needs to be updated after merging this PR.
